### PR TITLE
Fixes An Issue With Every Hour Cron Schedules

### DIFF
--- a/server/schedule.py
+++ b/server/schedule.py
@@ -85,13 +85,13 @@ class Schedule(ImageContent):
         except ValueError as e:
             raise ContentError(e)
 
-    def _prev(seld, cron, before, user):
-        """Finds the previous time matching the cron expression"""
+    def _previous(self, cron, before, user):
+        """Finds the previous time matching the cron expression."""
 
         try:
-            cron = seld._sun.rewrite_cron(cron, before, user)
+            cron = self._sun.rewrite_cron(cron, before, user)
         except DataError as e:
-            raise ContentError
+            raise ContentError(e)
 
         try:
             return croniter(cron, before, user).get_prev(datetime)
@@ -125,9 +125,9 @@ class Schedule(ImageContent):
             time = self._local_time.now(user)
         except DataError as e:
             raise ContentError(e)
-        today = time.replace(hour=0, minute=0, second=0, microsecond=0)
+
         while True:
-            entries = [(self._prev(entry['start'], time, user), entry)
+            entries = [(self._previous(entry['start'], time, user), entry)
                        for entry in user.get('schedule')]
             if not entries:
                 raise ContentError('Empty schedule')

--- a/server/schedule.py
+++ b/server/schedule.py
@@ -89,12 +89,12 @@ class Schedule(ImageContent):
         """Finds the previous time matching the cron expression."""
 
         try:
-            cron = self._sun.rewrite_cron(cron, before, user)
+            cron = self._sun.rewrite_cron(cron, before, user, False)
         except DataError as e:
             raise ContentError(e)
 
         try:
-            return croniter(cron, before, user).get_prev(datetime)
+            return croniter(cron, before).get_prev(datetime)
         except ValueError as e:
             raise ContentError(e)
 
@@ -126,21 +126,14 @@ class Schedule(ImageContent):
         except DataError as e:
             raise ContentError(e)
 
-        while True:
-            entries = [(self._previous(entry['start'], time, user), entry)
-                       for entry in user.get('schedule')]
-            if not entries:
-                raise ContentError('Empty schedule')
-            past_entries = list(filter(lambda x: x[0] <= time, entries))
+        entries = [(self._previous(entry['start'], time, user), entry)
+                   for entry in user.get('schedule')]
 
-            # Use the most recent past entry.
-            if past_entries:
-                latest_datetime, latest_entry = max(past_entries,
-                                                    key=lambda x: x[0])
-                break
+        if not entries:
+            raise ContentError('Empty schedule')
 
-            # If there were no past entries, try the previous day.
-            time -= timedelta(days=1)
+        # Use the most recent past entry.
+        latest_datetime, latest_entry = max(entries, key=lambda x: x[0])
 
         # Generate the image from the current schedule entry.
         info('Using image from schedule entry: %s (%s, %s)' % (

--- a/server/sun.py
+++ b/server/sun.py
@@ -17,16 +17,19 @@ class Sun(object):
         self._astral = Astral(geocoder=GeocoderWrapper, wrapped=geocoder)
         self._local_time = LocalTime(geocoder)
 
-    def rewrite_cron(self, cron, after, user):
+    def rewrite_cron(self, cron, reference, user):
         """Replaces references to sunrise and sunset in a cron expression."""
 
         # Skip if there is nothing to rewrite.
         if 'sunrise' not in cron and 'sunset' not in cron:
             return cron
 
+        # Replace H:M:S in the reference time so that we get the correct sunrise / set
+        reference_midnight = reference.replace(hour=0, minute=0, second=0, microsecond=0)
+
         # Determine the first two days of the cron expression after the
         # reference, which covers all candidate sunrises and sunsets.
-        yesterday = after - timedelta(days=1)
+        yesterday = reference_midnight - timedelta(days=1)
         midnight_cron = cron.replace('sunrise', '0 0').replace('sunset', '0 0')
         try:
             first_day = croniter(midnight_cron, yesterday).get_next(datetime)
@@ -45,13 +48,13 @@ class Sun(object):
         if 'sunrise' in cron:
             sunrises = map(lambda x: home.sunrise(x).astimezone(zone),
                            [first_day, second_day])
-            next_sunrise = min(filter(lambda x: x >= after, sunrises))
+            next_sunrise = min(filter(lambda x: x >= reference_midnight, sunrises))
             sunrise_cron = cron.replace('sunrise', '%d %d' % (
                 next_sunrise.minute, next_sunrise.hour))
-            info('Rewrote cron: (%s) -> (%s), after %s' % (
+            info('Rewrote cron: (%s) -> (%s), reference %s' % (
                 cron,
                 sunrise_cron,
-                after.strftime('%A %B %d %Y %H:%M:%S %Z')))
+                reference_midnight.strftime('%A %B %d %Y %H:%M:%S %Z')))
             return sunrise_cron
 
         # Calculate the closest future sunset time and replace the term in the
@@ -59,13 +62,13 @@ class Sun(object):
         if 'sunset' in cron:
             sunsets = map(lambda x: home.sunset(x).astimezone(zone),
                           [first_day, second_day])
-            next_sunset = min(filter(lambda x: x >= after, sunsets))
+            next_sunset = min(filter(lambda x: x >= reference_midnight, sunsets))
             sunset_cron = cron.replace('sunset', '%d %d' % (next_sunset.minute,
                                                             next_sunset.hour))
-            info('Rewrote cron: (%s) -> (%s), after %s' % (
+            info('Rewrote cron: (%s) -> (%s), reference %s' % (
                 cron,
                 sunset_cron,
-                after.strftime('%A %B %d %Y %H:%M:%S %Z')))
+                reference_midnight.strftime('%A %B %d %Y %H:%M:%S %Z')))
             return sunset_cron
 
     def is_daylight(self, user):


### PR DESCRIPTION
I noticed an issue where if I have a schedule set to run every hour it will get overridden in favor of a schedule that only gets run at a specific hour that is before the current time.

The logic in schedule.py uses the start of the day as the starting point for the croniter. As such events that run hourly appear to happen before events that run at a specific hour of the day. To fix this I added a helper which indexes the croniter backwards from the current time instead of forwards from the start of the day. In my local testing this seems to have resolved the issue.