### PR TITLE
Center smaller artwork in the middle of the screen

### DIFF
--- a/server/artwork.py
+++ b/server/artwork.py
@@ -6,6 +6,7 @@ from random import choice
 from random import randint
 
 from content import ImageContent
+from epd import edge_color
 
 # The directory containing static artwork images.
 IMAGES_DIR = 'assets/artwork'
@@ -27,9 +28,17 @@ class Artwork(ImageContent):
         image = Image.open(filename)
         image = image.convert('RGB')
 
-        # Crop the image to a random display-sized area.
-        x = randint(0, max(0, image.width - width))
-        y = randint(0, max(0, image.height - height))
-        image = image.crop((x, y, x + width, y + height))
-
-        return image
+        # Larger images are cropped to a random display-sized area.
+        # Smaller images are centered in the middle of the display.
+        if width > image.width:
+            x = int((width - image.width) / 2)
+        else:
+            x = -randint(0, image.width - width)
+        if height > image.height:
+            y = int((height - image.height) / 2)
+        else:
+            y = -randint(0, image.height - height)
+        
+        output = Image.new('RGB', (width, height), color=edge_color(image))
+        output.paste(image, (x, y))
+        return output

--- a/server/epd.py
+++ b/server/epd.py
@@ -1,6 +1,8 @@
+from numpy import argmax
 from numpy import array
 from numpy import packbits
 from numpy import uint8
+from numpy import unique
 from PIL import Image
 from scipy.cluster.vq import vq
 
@@ -49,3 +51,20 @@ def adjust_xy(x, y, width, height):
     y += (height - DEFAULT_DISPLAY_HEIGHT) // 2
 
     return x, y
+
+
+def edge_color(image):
+    """Returns the most common color (r, g, b) of the image edge.
+
+    Looks at the pixels at the edge of the image and returns the most
+    common color. This is then used as a background color in case display
+    size is larger than the image size.
+    """
+    i = array(bwr_image(image))
+    edge = array(
+        list(i[0]) +  # top
+        list(i[-1]) +  # bottom
+        [r[0] for r in i] + # left
+        [r[-1] for r in i]) # right
+    values, counts = unique(edge, axis=0, return_counts=True)
+    return tuple(values[argmax(counts)])


### PR DESCRIPTION
Instead of displaying the image in the top left corner with a black background, this will center smaller images in the middle of the screen, using an appropriate background color depending on the edge of the image.

Related to #12.