### PR TITLE
Use actual number of weeks to determine spacing between calendar rows

### DIFF
--- a/server/google_calendar.py
+++ b/server/google_calendar.py
@@ -33,9 +33,6 @@ CALENDAR_ID = 'primary'
 # The number of days in a week.
 DAYS_IN_WEEK = 7
 
-# The maximum nubmer of (partial) weeks in a month.
-WEEKS_IN_MONTH = 6
-
 # The color of the image background.
 BACKGROUND_COLOR = (255, 255, 255)
 
@@ -160,13 +157,13 @@ class GoogleCalendar(ImageContent):
                           color=BACKGROUND_COLOR)
         draw = Draw(image)
 
-        # Determine the spacing of the days in the image.
-        x_stride = width // (DAYS_IN_WEEK + 1)
-        y_stride = height // (WEEKS_IN_MONTH + 1)
-
         # Get this month's calendar.
         calendar = Calendar(firstweekday=SUNDAY)
         weeks = calendar.monthdayscalendar(time.year, time.month)
+
+        # Determine the spacing of the days in the image.
+        x_stride = width // (DAYS_IN_WEEK + 1)
+        y_stride = height // (len(weeks) + 1)
 
         # Draw each week in a row.
         for week_index in range(len(weeks)):


### PR DESCRIPTION
This fixes alignment for months that can be displayed in fewer than 6 rows.

Before:
---
![calendar-old](https://user-images.githubusercontent.com/1687799/118397240-fe95d700-b64a-11eb-9b38-9f222ca119c5.gif)
---

After:
---
![calendar-new](https://user-images.githubusercontent.com/1687799/118397243-02c1f480-b64b-11eb-90f1-d4f7d52c8efb.gif)
---