### PR TITLE
[codex] Update AIcon Imagen model

### DIFF
--- a/server/aicon.py
+++ b/server/aicon.py
@@ -16,7 +16,7 @@ Eastern Christian Orthodox icon with artificial intelligence elements
 """
 
 # The model to use for image generation.
-IMAGE_MODEL = 'imagen-4.0-ultra-generate-preview-06-06'
+IMAGE_MODEL = 'imagen-4.0-ultra-generate-001'
 
 # The scope for authenticating with the Google Cloud Vertex AI API.
 AUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'


### PR DESCRIPTION
## Summary
- Change AIcon's Vertex AI Imagen model from `imagen-4.0-ultra-generate-preview-06-06` to `imagen-4.0-ultra-generate-001`.

## Motivation
The old preview model now returns `404 Not Found` from Vertex AI. Google lists the preview Imagen 4 models as removed and identifies `imagen-4.0-ultra-generate-001` as the GA Imagen 4 Ultra generation model.

## Scope
This PR is intentionally model-only. It does not include dependency upgrades or API cleanup; those belong in a separate upgrade PR.

## Validation
- Confirmed the PR diff contains only the one model constant change in `server/aicon.py`.
- Verified the updated model constant imports from `server/aicon.py`.
