### PR TITLE
[codex] Speed up everyone image

### DIFF
--- a/server/everyone.py
+++ b/server/everyone.py
@@ -1,5 +1,6 @@
 from cachetools import cached
 from cachetools import TTLCache
+from cachetools.keys import methodkey
 from content import ContentError
 from content import ImageContent
 from firestore import DataError
@@ -13,6 +14,9 @@ MARKER_ICON_URL = 'http://accent.ink/marker.png'
 # The time to live in seconds for cached markers.
 CACHE_TTL_S = 24 * 60 * 60  # 1 day
 
+# The maximum number of rendered everyone images kept in the cache.
+MAX_IMAGE_CACHE_SIZE = 4
+
 
 class Everyone(ImageContent):
     """A map of Accent users around the world."""
@@ -22,36 +26,47 @@ class Everyone(ImageContent):
         self._google_maps = GoogleMaps(geocoder)
         self._firestore = Firestore()
 
-    @cached(cache=TTLCache(maxsize=1, ttl=CACHE_TTL_S))
+    @cached(cache=TTLCache(maxsize=1, ttl=CACHE_TTL_S), key=methodkey)
     def _markers(self):
         """Returns a list of users' home locations to be shown on a map."""
 
-        markers = ''
+        markers = []
+        seen_markers = set()
 
-        for user in self._firestore.users():
+        for user in self._firestore.users(field_paths=['home']):
             try:
                 home = user.get('home')
-                location = self._geocoder[home]
+                location = self._geocoder.geocode(home)
 
                 # Use the latitude and longitude of the city name and region
                 # instead of the exact coordinates to anonymize user addresses.
                 city = '%s, %s' % (location.name, location.region)
-                anonymized = self._geocoder[city]
+                anonymized = self._geocoder.geocode(city)
 
-                markers += '|%f,%f' % (anonymized.latitude,
-                                       anonymized.longitude)
+                marker = '%f,%f' % (anonymized.latitude,
+                                    anonymized.longitude)
+                if marker not in seen_markers:
+                    seen_markers.add(marker)
+                    markers.append(marker)
             except (KeyError, DataError):
                 # Skip users with address errors.
                 pass
 
-        return markers
+        return '|'.join(markers)
 
     def image(self, user, width, height, variant):
         """Generates a map with user locations."""
 
+        return self._image(width, height, variant, self._markers()).copy()
+
+    @cached(cache=TTLCache(maxsize=MAX_IMAGE_CACHE_SIZE, ttl=CACHE_TTL_S),
+            key=methodkey)
+    def _image(self, width, height, variant, markers):
+        """Generates and caches a map with user locations."""
+
         try:
             image = self._google_maps.map_image(width, height, variant,
-                                                markers=self._markers(),
+                                                markers=markers,
                                                 marker_icon=MARKER_ICON_URL)
 
             # The map looks better without dithering.

--- a/server/firestore.py
+++ b/server/firestore.py
@@ -159,10 +159,14 @@ class Firestore(object):
 
         return user
 
-    def users(self):
+    def users(self, field_paths=None):
         """Returns an iterator over all users."""
 
-        return self._db.collection('users').stream()
+        users = self._db.collection('users')
+        if field_paths:
+            users = users.select(field_paths)
+
+        return users.stream()
 
     def _user_reference(self, key):
         """Retrieves the user reference matching the specified key."""

--- a/server/geocoder.py
+++ b/server/geocoder.py
@@ -28,6 +28,17 @@ REQUEST_TIMEOUT_S = 10
 
 
 @dataclass(frozen=True)
+class GeocodedLocation(object):
+    """A geocoded location without timezone or elevation metadata."""
+
+    name: str
+    region: str
+    latitude: float
+    longitude: float
+    url: str
+
+
+@dataclass(frozen=True)
 class Location(object):
     """A geocoded location with the fields used by the server."""
 
@@ -47,20 +58,32 @@ class Geocoder(object):
         self._google_maps_api_key = Firestore().google_maps_api_key()
 
     @cached(cache=TTLCache(maxsize=MAX_CACHE_SIZE, ttl=CACHE_TTL_S))
-    def __getitem__(self, key):
+    def geocode(self, key):
+        """Looks up coordinates for an address."""
+
         name, region, latitude, longitude = self._geocoding(key)
-        timezone = self._timezone(latitude, longitude)
-        elevation = self._elevation(latitude, longitude)
         url = 'https://maps.google.com/maps?q=loc:%f,%f' % (
             latitude, longitude)
 
-        return Location(name=name,
-                        region=region,
-                        latitude=latitude,
-                        longitude=longitude,
+        return GeocodedLocation(name=name,
+                                region=region,
+                                latitude=latitude,
+                                longitude=longitude,
+                                url=url)
+
+    @cached(cache=TTLCache(maxsize=MAX_CACHE_SIZE, ttl=CACHE_TTL_S))
+    def __getitem__(self, key):
+        location = self.geocode(key)
+        timezone = self._timezone(location.latitude, location.longitude)
+        elevation = self._elevation(location.latitude, location.longitude)
+
+        return Location(name=location.name,
+                        region=location.region,
+                        latitude=location.latitude,
+                        longitude=location.longitude,
                         timezone=timezone,
                         elevation=elevation,
-                        url=url)
+                        url=location.url)
 
     def _request_json(self, url, params):
         """Requests JSON from a Google Maps API endpoint."""

--- a/server/google_maps.py
+++ b/server/google_maps.py
@@ -1,5 +1,6 @@
 from cachetools import cached
 from cachetools import TTLCache
+from cachetools.keys import methodkey
 from google.cloud import vision
 from io import BytesIO
 from logging import warning
@@ -45,6 +46,9 @@ MAX_CACHE_SIZE = 10
 
 # The time to live in seconds for cached map images.
 CACHE_TTL_S = 24 * 60 * 60  # 1 day
+
+# The timeout for Google Maps image requests.
+REQUEST_TIMEOUT_S = 10
 
 
 class GoogleMaps(object):
@@ -105,7 +109,9 @@ class GoogleMaps(object):
                                          hide_map=hide_map)
 
         try:
-            return get(image_url).content
+            response = get(image_url, timeout=REQUEST_TIMEOUT_S)
+            response.raise_for_status()
+            return response.content
         except RequestException as e:
             raise DataError(e)
 
@@ -136,9 +142,18 @@ class GoogleMaps(object):
         time = self._local_time.utc_now()
         return COPYRIGHT_TEXT % time.year
 
-    @cached(cache=TTLCache(maxsize=MAX_CACHE_SIZE, ttl=CACHE_TTL_S))
     def map_image(self, width, height, variant, polyline=None, markers=None,
                   marker_icon=None):
+        """Creates a map image with optional route or markers."""
+
+        return self._map_image(width, height, variant, polyline=polyline,
+                               markers=markers,
+                               marker_icon=marker_icon).copy()
+
+    @cached(cache=TTLCache(maxsize=MAX_CACHE_SIZE, ttl=CACHE_TTL_S),
+            key=methodkey)
+    def _map_image(self, width, height, variant, polyline=None, markers=None,
+                   marker_icon=None):
         """Creates a map image with optional route or markers."""
 
         # Get the static map as an image.
@@ -169,7 +184,7 @@ class GoogleMaps(object):
                           box_padding=COPYRIGHT_BOX_PADDING,
                           image=image)
 
-                return image
+                return image.copy()
 
     def _route_url(self, home, work, travel_mode):
         """Constructs the URL for the Directions API request."""


### PR DESCRIPTION
## Summary
- Speed up the everyone image by caching rendered outputs and sharing cached map generation across instances.
- Reduce cold marker-generation work by fetching only user home fields, using coordinate-only geocoding, and deduplicating identical city markers.
- Add map download timeout/status handling while preserving copy safety for cached PIL images.

## Root Cause
The everyone image performed unnecessary work on cold generation: full geocoder lookups also fetched timezone/elevation metadata, duplicate city markers were kept, and map-image caching was tied to object identity.

## Validation
- `venv/bin/python -m compileall -q . -x './venv'`
- Mocked hot-path checks for marker generation, lightweight geocoder reuse, everyone image caching/copy safety, and Google map cache/copy safety were run locally before publishing.